### PR TITLE
fix(ci): avoid publish/test concurrency deadlock

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,11 @@ on:
     branches: [main, master]
   workflow_call:
 
+# Suffix keeps this group distinct from a caller's group when run via
+# workflow_call (github.workflow resolves to the caller), avoiding a
+# self-deadlock with publish.yml's concurrency group.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-test
   cancel-in-progress: true
 
 permissions: {}


### PR DESCRIPTION
## Problem

The `Publish` workflow on `main` was cancelled with:

> Canceling since a deadlock was detected for concurrency group: 'Publish-refs/heads/main' between a top level workflow and 'Test'

`publish.yml` sets a top-level `concurrency` group of `${{ github.workflow }}-${{ github.ref }}` **and** runs the test suite via `uses: ./.github/workflows/test.yml`. Inside a reusable (called) workflow, `github.workflow` resolves to the **caller** (`Publish`), so `test.yml`'s own concurrency group also evaluated to `Publish-refs/heads/main` — identical to its parent. The parent waits on the child while the child queues behind the parent in the same group, which GitHub detects as a deadlock and cancels.

## Fix

Append a `-test` suffix to `test.yml`'s concurrency group so a called run stays distinct from the caller's group (`Publish-refs/heads/main-test` ≠ `Publish-refs/heads/main`). Standalone PR runs still dedupe (`Test-<ref>-test`).

Only `base-configs-eslint` is affected — it's the only repo whose `publish.yml` calls `test.yml`.

Verified: `zizmor test.yml` → no findings; YAML valid.